### PR TITLE
GH-6 • Create Metadata Frontmatter Logic

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,9 +1,15 @@
+---
+const { metadata } = Astro.props;
+const title = metadata?.title || "Dan Arbello | Design | Engineering";
+const description = metadata?.description || "A unique breed of both visual and logical design: blending the role of a creative leader and bridging the gap between engineers and designers.";
+---
+
 <head>
   <meta charset="UTF-8" />
-  <title>Dan Arbello | Design | Engineering</title>
-  <meta content="A unique breed of both visual and logical design: blending the role of a creative leader and bridging the gap between engineers and designers." name="description">
-  <meta content="Dan Arbello | Design | Engineering" property="og:title">
-  <meta content="A unique breed of both visual and logical design: blending the role of a creative leader and bridging the gap between engineers and designers." property="og:description">
+  <title>{title}</title>
+  <meta content={description} name="description">
+  <meta content={title} property="og:title">
+  <meta content={description} property="og:description">
   <meta property="og:type" content="website">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -2,13 +2,16 @@
 import Head from '../components/Head.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+
 import '../styles/global.css';
 import '../styles/modifiers.css';
+
+const { metadata } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
-	<Head />
+	<Head {metadata} />
 	<Header />
 	<body>
 		<slot />

--- a/src/pages/case-studies/aerospace.astro
+++ b/src/pages/case-studies/aerospace.astro
@@ -4,13 +4,18 @@ import '../../styles/patterns.css';
 import { Image } from 'astro:assets';
 import imageInline01 from '../../assets/images/inline__aerospace_metabylines.gif';
 import imageInline02 from '../../assets/images/inline__aerospace_metateasers.gif';
+
+const metadata = {
+  title: 'Guiding Aerospace’s Content Strategy and Procedures Into the Future',
+  description: 'Aerospace faced significant challenges with their outdated website, where disparate labs/entities published content without a proper editing process. We humanized their voice, focusing on the humans that make Aerospace an authority.'
+};
 ---
 
-<Basic>
+<Basic {metadata}>
   <section class="case-study">
     <div class="container">
       <p class="eyebrow small--extra">Case Study</p>
-      <h1 class="largest">Guiding Aerospace’s Content Strategy and Procedures Into the Future</h1>
+      <h1 class="largest">{metadata.title}</h1>
       <div class="site-viewer" style="background-image: url('/images/siteviewers/siteviewer__aerospace.webp')" aria-label="Screen capture of Aerospace.org"></div>
       <div class="case-study__details small--extra row left-align row--four row--compact">
         <p class="column">Agency: <a href="https://thirdandgrove.com" target="_blank">Third & Grove</a></p>

--- a/src/pages/case-studies/draper.astro
+++ b/src/pages/case-studies/draper.astro
@@ -1,13 +1,18 @@
 ---
 import Basic from '../../layouts/Basic.astro';
 import '../../styles/patterns.css';
+
+const metadata = {
+  title: 'Bestowing Draper Labs With a History-Driven Web Experience',
+  description: 'The renowned R&D organization, collaborated with us to undertake a comprehensive redesign and overhaul of their website and celebrate their assitance in getting us to the moon 50 years ago.'
+};
 ---
 
-<Basic>
+<Basic {metadata}>
   <section class="case-study">
     <div class="container">
       <p class="eyebrow small--extra">Case Study</p>
-      <h1 class="largest">Bestowing Draper Labs With a History-Driven Web Experience</h1>
+      <h1 class="largest">{metadata.title}</h1>
       <div class="site-viewer" style="background-image: url('/images/siteviewers/siteviewer__draper.webp')" aria-label="Screen capture of Draper.com"></div>
       <div class="case-study__details small--extra row left-align row--four row--compact">
         <p class="column">Agency: <a href="https://thirdandgrove.com" target="_blank">Third & Grove</a></p>

--- a/src/pages/case-studies/imprivata.astro
+++ b/src/pages/case-studies/imprivata.astro
@@ -1,13 +1,18 @@
 ---
 import Basic from '../../layouts/Basic.astro';
 import '../../styles/patterns.css';
+
+const metadata = {
+  title: 'Unlocking Imprivata’s Coverage for Several New Markets',
+  description: 'Consulting with a security/SaaS organization to expand their brand goodwill, reach greater markets, and integrate recently acquired subsidiaries into their marketing website.'
+};
 ---
 
-<Basic>
+<Basic {metadata}>
   <section class="case-study">
     <div class="container">
       <p class="eyebrow small--extra">Case Study</p>
-      <h1 class="largest">Unlocking Imprivata’s Coverage for Several New Markets</h1>
+      <h1 class="largest">{metadata.title}</h1>
       <div class="site-viewer" style="background-image: url('/images/siteviewers/siteviewer__imprivata.webp')" aria-label="Screen capture of Imprivata.com"></div>
       <div class="case-study__details small--extra row left-align row--four row--compact">
         <p class="column">Agency: <a href="https://chromatichq.com" target="_blank">Chromatic</a></p>

--- a/src/pages/case-studies/sunpower.astro
+++ b/src/pages/case-studies/sunpower.astro
@@ -4,13 +4,18 @@ import '../../styles/patterns.css';
 import { Image } from 'astro:assets';
 import imageInline01 from '../../assets/images/inline__sunpower_leadgenfunneling.gif';
 import imageInline02 from '../../assets/images/inline__sunpower_map.gif';
+
+const metadata = {
+  title: 'Enlightening SunPower’s Key Lead Generation Funnel',
+  description: 'As the Design Lead on this project, I conducted an in-depth analysis, identify opportunities for improvement, and implement a comprehensive solution tailored to meet SunPower‘s business requirements and SEO/marketing goals.'
+};
 ---
 
-<Basic>
+<Basic {metadata}>
   <section class="case-study">
     <div class="container">
       <p class="eyebrow small--extra">Case Study</p>
-      <h1 class="largest">Enlightening SunPower’s Key Lead Generation Funnel</h1>
+      <h1 class="largest">{metadata.title}</h1>
       <div class="case-study__details small--extra row left-align row--four row--compact">
         <p class="column">Agency: <a href="https://thirdandgrove.com" target="_blank">Third & Grove</a></p>
         <p class="column">Role: Design Lead</p>

--- a/src/pages/case-studies/swedish-news.astro
+++ b/src/pages/case-studies/swedish-news.astro
@@ -11,13 +11,18 @@ import imageInline06 from '../../assets/images/inline__nordic_reach_05.jpeg';
 import imageInline07 from '../../assets/images/inline__nordic_reach_06.jpeg';
 import imageInline08 from '../../assets/images/inline__nordstjernan_01.jpeg';
 import imageInline09 from '../../assets/images/inline__nordstjernan_02.jpeg';
+
+const metadata = {
+  title: 'A Decade+ of Leading the Creative for a Scandinavian Lifestyle Publisher',
+  description: 'I served as a creative director for over ten years on all properties for Swedish News Inc., including the prestigious Nordic Reach magazine and the historic Nordstjernan newspaper.'
+};
 ---
 
-<Basic>
+<Basic {metadata}>
   <section class="case-study">
       <div class="container">
         <p class="eyebrow small--extra">Case Study</p>
-        <h1 class="largest">A Decade+ of Leading the Creative for a Scandinavian Lifestyle Publisher</h1>
+        <h1 class="largest">{metadata.title}</h1>
         <div class="case-study__details small--extra row left-align row--four row--compact">
           <p class="column">Agency: Self</p>
           <p class="column">Role: Art Director</p>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. The sections suggested are intended to make -->
<!-- it easy to create a descriptive PR that is easy to review. Change as needed! -->

This PR sets up the frontmatter feeds (starting with `title` and `description`, consumed by `components/Head`) for pages using `layouts/Basic`.

## Motivation / Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes or is related to an open issue, link to the issue here. -->

Resolves #6 

## Testing Instructions / How This Has Been Tested
<!-- Describe how you tested your changes and/or how a reviewer can test your changes. -->

- Access the preview and ensure the page title and description are always supplied in the `head`.

## Screenshots
<!-- Would including screenshots be helpful to the reviewer? -->

<img width="1006" alt="Screenshot 2025-03-09 at 20 00 32" src="https://github.com/user-attachments/assets/527fc81c-7f58-4304-924f-2c090e49cbaa" />
