### PR TITLE
remove matomo script from Head.astro

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -13,16 +13,4 @@ const description = metadata?.description || "A unique breed of both visual and 
   <meta property="og:type" content="website">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
-  <script>
-    var _paq = window._paq = window._paq || [];
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="https://danarbello.matomo.cloud/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '1']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src='https://cdn.matomo.cloud/danarbello.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
 </head>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. The sections suggested are intended to make -->
<!-- it easy to create a descriptive PR that is easy to review. Change as needed! -->

This removes the Matomo script from the `Head.astro` component.

## Motivation / Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes or is related to an open issue, link to the issue here. -->

Related to #35 

## How this can be tested
- Access the Vercel preview
- Open Inspector
- Ensure there is no console error about Matomo